### PR TITLE
Remove unrequire in favor of marshmallow's partial

### DIFF
--- a/flask_stupe/validation.py
+++ b/flask_stupe/validation.py
@@ -11,25 +11,10 @@ except ImportError:  # pragma: no cover
 
 
 if marshmallow:
-    def unrequire(schema_or_field):
-        if isinstance(schema_or_field, marshmallow.fields.List):
-            unrequire(schema_or_field.container)
-        elif isinstance(schema_or_field, marshmallow.fields.Nested):
-            unrequire(schema_or_field.schema)
-        elif isinstance(schema_or_field, marshmallow.Schema):
-            for field in schema_or_field.fields.values():
-                unrequire(field)
-        if isinstance(schema_or_field, marshmallow.fields.Field):
-            schema_or_field.required = False
-
     class Schema(marshmallow.Schema):
 
         def __init__(self, *args, **kwargs):
-            _unrequire = kwargs.pop("unrequire", False)
             super(Schema, self).__init__(*args, **kwargs)
-
-            if _unrequire:
-                unrequire(self)
 
     def schema_required(schema):
         """Validate body of the request against the schema.
@@ -47,4 +32,4 @@ if marshmallow:
             return __inner
         return __inner
 
-    __all__.extend(["unrequire", "Schema", "schema_required"])
+    __all__.extend(["Schema", "schema_required"])

--- a/tests/validation.py
+++ b/tests/validation.py
@@ -2,48 +2,7 @@ import json
 
 from flask import request
 from flask_stupe.validation import Schema, schema_required
-from marshmallow.fields import Integer, List, Nested
-
-
-def test_unrequire():
-    class TestSchema(Schema):
-        foo = Integer(required=True)
-
-    schema = TestSchema()
-    assert schema.validate({}) == {"foo": ["Missing data for required field."]}
-
-    schema = TestSchema(unrequire=True)
-    assert schema.validate({}) == {}
-
-
-def test_unrequire_list():
-    class TestSchema(Schema):
-        foo = List(Integer, required=True)
-
-    schema = TestSchema()
-    assert schema.validate({}) == {"foo": ["Missing data for required field."]}
-
-    schema = TestSchema(unrequire=True)
-    assert schema.validate({}) == {}
-
-
-def test_unrequire_nested():
-    class NestedSchema(Schema):
-        foo = Integer(required=True)
-
-    class TestSchema(Schema):
-        foo = Nested(NestedSchema(), required=True)
-
-    schema = TestSchema()
-    assert schema.validate({}) == {
-        "foo": {
-            "foo": ["Missing data for required field."]
-        }
-    }
-
-    schema = TestSchema(unrequire=True)
-    assert schema.validate({}) == {}
-    assert schema.validate({"foo": {}}) == {}
+from marshmallow.fields import Integer
 
 
 def test_schema_required(app):


### PR DESCRIPTION
This PR allows the use of **marshmallow**'s load keyword `partial` instead of `unrequire`.