### PR TITLE
Setup Travis & Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy3"
+install:
+  - pip install -r requirements.txt
+  - pip install flake8
+  - pip install coveralls
+before_script: flake8
+script: pytest
+after_success: coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 pymongo
 marshmallow
 
-pytest
+pytest==3.5.0
 pytest-cov
 
 Sphinx


### PR DESCRIPTION
Fixes #1.

I enabled Travis & Coveralls on my fork for testing purposes. Once this PR is accepted, that will be disabled and should be enabled on @numberly side.

I pinned `pytest` to its latest version (3.5.0) so some tests don't fail anymore because of a missing dependency (`pytest-catchlog`) that was merged into `pytest` core.