### PR TITLE
Add the possibility to sort using a collation

### DIFF
--- a/flask_stupe/__init__.py
+++ b/flask_stupe/__init__.py
@@ -20,6 +20,11 @@ try:
 except ImportError:  # pragma: no cover
     pymongo = False
 
+try:
+    from pymongo.collation import Collation
+except ImportError:  # pragma: no cover
+    Collation = False
+
 from flask_stupe.app import Stupeflask
 from flask_stupe.validation import *
 from flask_stupe.pagination import *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,22 @@ class Cursor(pymongo.cursor.Cursor):
         return self.data
 
     def sort(self, sort):
+        self.sort_data = sort
         for sort_key, order in reversed(sort):
-            self.data = sorted(self.data, key=lambda d: d.get(sort_key, 0))
+
+            def get_key(d):
+                if hasattr(self, "collation_data"):
+                    return d.get(sort_key, 0).lower()
+                return d.get(sort_key, 0)
+
+            self.data = sorted(self.data, key=get_key)
             if order == -1:
                 self.data.reverse()
         return self.data
+
+    def collation(self, collation):
+        self.collation_data = collation
+        return self.sort(self.sort_data)
 
     def count(self):
         return len(self.data)

--- a/tests/pagination.py
+++ b/tests/pagination.py
@@ -1,7 +1,7 @@
 import pytest
 from flask import Flask, request
 
-from flask_stupe import Stupeflask, paginate
+from flask_stupe import Collation, Stupeflask, paginate
 from tests.conftest import Cursor
 
 
@@ -55,6 +55,23 @@ def test_paginate_sort(app):
                            {"foo": 1}, {"foo": 3}, {"foo": 2}])
         assert foobar().data == [{"bar": 3}, {"bar": 2}, {"bar": 1},
                                  {"foo": 1}, {"foo": 2}, {"foo": 3}]
+
+
+@pytest.mark.parametrize("app", [
+    Stupeflask(__name__),
+    Flask(__name__)
+])
+def test_paginate_collation(app):
+    with app.test_request_context():
+        @paginate(sort=["foo"], collation="en")
+        def paginate_1():
+            return Cursor([{"foo": "Ber"}, {"foo": "foo"}, {"foo": "bar"}])
+        if not Collation:
+            expected_result = [{"foo": "Ber"}, {"foo": "bar"}, {"foo": "foo"}]
+            assert paginate_1().data == expected_result
+        if Collation:
+            expected_result = [{"foo": "bar"}, {"foo": "Ber"}, {"foo": "foo"}]
+            assert paginate_1() == expected_result
 
 
 @pytest.mark.parametrize("app", [


### PR DESCRIPTION
This is done when you want to sort using a lexicographical order:
Ber, bar, foo
becomes
bar, Ber, foo

See https://docs.mongodb.com/manual/reference/collation/