### PR TITLE
feat(pagination): support pymongo-4 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,14 @@ Session.vim
 # SublimeText
 *.sublime-workspace
 
+# VScode
+.vscode
+
 # PyCharm
 .idea
 .iml
 
 # virtualenv
 .venv*
+venv*
 src/

--- a/flask_stupe/pagination.py
+++ b/flask_stupe/pagination.py
@@ -11,8 +11,9 @@ if pymongo:
     def _paginate(cursor, skip=None, limit=None, sort=None, count=True,
                   collation=None):
         metadata = getattr(request, "metadata", None)
+        # thdo: we can't extract cursor length anymore from pymongo.cursor.Cursor without consume it
         if count and isinstance(metadata, dict):
-            metadata.update(count=cursor.count())
+            metadata.update(count=len(list(cursor.clone())))
 
         skip = request.args.get("skip", skip, type=int)
         if skip is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,12 @@ class Cursor(pymongo.cursor.Cursor):
     def __del__(self):
         pass
 
+    def __iter__(self):
+        return iter(self.data)
+
+    def __empty(self):
+        return len(self.data) == 0
+
     def skip(self, skip):
         del self.data[:skip]
         return self.data


### PR DESCRIPTION
Implementation: need to support pymongo-4.x as it [deletes cursor.count()](https://pymongo.readthedocs.io/en/stable/changelog.html#breaking-changes-in-4-0).

The `count_document` method is now part of the `collection` instead of `cursor`.  To simplify we chose to clone cursor, consume it as a list, then get list length.